### PR TITLE
Feature: Add new 'Music' type representing Isaac's latest releases

### DIFF
--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,9 +1,131 @@
+import { getMusic } from "@/sanity/queries";
+import type { Music } from "@/types/sanity.types";
+import { urlFor } from "@/sanity/lib/urlFor";
+import Image from "next/image";
+
 export const revalidate = 300;
 
-export default function Music() {
+export default async function MusicPage() {
+  const music: Music[] = await getMusic();
+
   return (
-    <div className="flex h-screen flex-col items-center justify-center">
-      <h1 className="text-4xl font-bold">Music</h1>
+    <div className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-6 md:p-8 lg:px-24">
+      <div className="w-full max-w-6xl">
+        <h1 className="mb-8 text-center text-3xl font-bold text-[#e0d6c3] sm:text-4xl lg:text-5xl">
+          Music
+        </h1>
+
+        {music && music.length > 0 ? (
+          <div className="space-y-12">
+            {music.map((album) => (
+              <div
+                key={album._id}
+                className="flex flex-col items-center space-y-6 rounded-lg bg-white/5 p-6 backdrop-blur-sm sm:flex-row sm:space-y-0 sm:space-x-8"
+              >
+                {/* Album Cover */}
+                {album.albumCover && album.albumCover.asset && (
+                  <div className="flex-shrink-0">
+                    <Image
+                      src={urlFor(album.albumCover).url()}
+                      alt={album.albumName || "Album Cover"}
+                      className="h-48 w-48 rounded-lg object-cover shadow-lg sm:h-56 sm:w-56"
+                      width={224}
+                      height={224}
+                    />
+                  </div>
+                )}
+
+                {/* Album Info and Player */}
+                <div className="flex flex-1 flex-col space-y-4">
+                  {/* Album Title and Artist */}
+                  <div className="text-center sm:text-left">
+                    <h2 className="text-2xl font-bold text-[#e0d6c3] sm:text-3xl">
+                      {album.albumName || "Untitled Album"}
+                    </h2>
+                    <p className="text-lg text-gray-300 sm:text-xl">
+                      {album.artistName || "Isaac Tea"}
+                    </p>
+                    {album.releaseDate && (
+                      <p className="text-sm text-gray-400">
+                        Released:{" "}
+                        {new Date(album.releaseDate).toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Songs List (if no album name) */}
+                  {!album.albumName &&
+                    album.songs &&
+                    album.songs.length > 0 && (
+                      <div className="text-center sm:text-left">
+                        <h3 className="mb-2 text-lg font-semibold text-[#e0d6c3]">
+                          Songs:
+                        </h3>
+                        <ul className="space-y-1">
+                          {album.songs.map((song, index) => (
+                            <li key={index} className="text-gray-300">
+                              {song}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                  {/* Bandcamp Player */}
+                  {album.bandcampEmbed && (
+                    <div className="w-full">
+                      <div
+                        className="w-full"
+                        dangerouslySetInnerHTML={{
+                          __html: album.bandcampEmbed,
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  {/* Streaming Links */}
+                  <div className="flex flex-wrap justify-center gap-4 sm:justify-start">
+                    {album.bandcampLink && (
+                      <a
+                        href={album.bandcampLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-full bg-orange-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-700"
+                      >
+                        Bandcamp
+                      </a>
+                    )}
+                    {album.spotifyUrl && (
+                      <a
+                        href={album.spotifyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-full bg-green-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700"
+                      >
+                        Spotify
+                      </a>
+                    )}
+                    {album.appleMusicUrl && (
+                      <a
+                        href={album.appleMusicUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-full bg-pink-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-pink-700"
+                      >
+                        Apple Music
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center justify-center py-12">
+            <p className="text-center text-lg text-gray-400">No music found.</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { getHomePage } from "@/sanity/queries";
 import { urlFor } from "@/sanity/lib/urlFor";
 import Image from "next/image";
 import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
+import type { Music } from "@/types/sanity.types";
 export const revalidate = 300;
 
 // Define types for the blocks
@@ -19,7 +20,14 @@ interface TextBlock {
   _type: "textBlock";
   text: string;
 }
-type PageBlock = ImageBlock | VideoBlock | TextBlock;
+interface MusicReference {
+  _type: "reference";
+  _ref: string;
+  _key: string;
+  // The referenced music document will be populated by the query
+  music?: Music;
+}
+type PageBlock = ImageBlock | VideoBlock | TextBlock | MusicReference;
 
 function getYouTubeEmbedUrl(url: string): string {
   try {
@@ -91,6 +99,91 @@ function renderBlock(block: PageBlock, idx: number) {
           </p>
         </div>
       );
+    case "reference":
+      // Check if this is a music reference by looking for the music field
+      if (block.music) {
+        return (
+          <div
+            className="mx-auto my-8 w-full max-w-6xl px-4 sm:my-12 sm:px-8 md:my-16 md:px-16 lg:px-24"
+            key={idx}
+          >
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+              {/* Left Column - Album Art */}
+              <div className="flex justify-center lg:justify-start">
+                {block.music.albumCover && block.music.albumCover.asset ? (
+                  <div className="relative">
+                    <Image
+                      src={urlFor(block.music.albumCover).url()}
+                      alt={block.music.albumName || "Album Cover"}
+                      className="h-80 w-80 rounded-lg object-cover shadow-2xl lg:h-96 lg:w-96"
+                      width={384}
+                      height={384}
+                    />
+                  </div>
+                ) : (
+                  <div className="flex h-80 w-80 items-center justify-center rounded-lg bg-gray-800 shadow-2xl lg:h-96 lg:w-96">
+                    <span className="text-gray-400">Album Art</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Right Column - Music Player & Info */}
+              <div className="flex flex-col justify-start space-y-6">
+                {/* Bandcamp Player */}
+                {block.music.bandcampEmbed && (
+                  <div className="w-full">
+                    <div
+                      className="w-full"
+                      dangerouslySetInnerHTML={{
+                        __html: block.music.bandcampEmbed,
+                      }}
+                    />
+                  </div>
+                )}
+
+                {/* Separator Line */}
+                <div className="border-t border-gray-600"></div>
+
+                {/* Streaming Links */}
+                <div className="flex flex-wrap justify-center gap-4 lg:justify-start">
+                  {block.music.bandcampLink && (
+                    <a
+                      href={block.music.bandcampLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-orange-400"
+                    >
+                      Bandcamp
+                    </a>
+                  )}
+                  {block.music.appleMusicUrl && (
+                    <a
+                      href={block.music.appleMusicUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-pink-400"
+                    >
+                      Apple Music
+                    </a>
+                  )}
+                  {block.music.spotifyUrl && (
+                    <a
+                      href={block.music.spotifyUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-green-400"
+                    >
+                      Spotify
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      }
+      // If it's not a music reference, return null
+      return null;
     default:
       return null;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { getHomePage } from "@/sanity/queries";
+import Link from "next/link";
 import { urlFor } from "@/sanity/lib/urlFor";
 import Image from "next/image";
 import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
@@ -104,79 +105,91 @@ function renderBlock(block: PageBlock, idx: number) {
       if (block.music) {
         return (
           <div
-            className="mx-auto my-8 w-full max-w-6xl px-4 sm:my-12 sm:px-8 md:my-16 md:px-16 lg:px-24"
+            className="w-fullpx-4 mx-auto py-12 sm:px-8 md:px-16 lg:px-24"
             key={idx}
           >
-            <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-              {/* Left Column - Album Art */}
-              <div className="flex justify-center lg:justify-start">
-                {block.music.albumCover && block.music.albumCover.asset ? (
-                  <div className="relative">
-                    <Image
-                      src={urlFor(block.music.albumCover).url()}
-                      alt={block.music.albumName || "Album Cover"}
-                      className="h-80 w-80 rounded-lg object-cover shadow-2xl lg:h-96 lg:w-96"
-                      width={384}
-                      height={384}
-                    />
+            <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
+              {/* Right Column - Music Player & Info */}
+              <div className="lg:order-2 lg:w-[800px]">
+                <div className="">
+                  {/* Title Text */}
+                  <div className="mb-6 flex">
+                    <h2 className="mr-4 text-2xl font-bold text-white lg:text-3xl">
+                      {`${block.music.albumName || "Untitled Album"}`}
+                    </h2>
+                    <h3 className="text-primary text-2xl lg:text-3xl">
+                      NEW EP OUT NOW!
+                    </h3>
                   </div>
-                ) : (
-                  <div className="flex h-80 w-80 items-center justify-center rounded-lg bg-gray-800 shadow-2xl lg:h-96 lg:w-96">
-                    <span className="text-gray-400">Album Art</span>
+
+                  {/* Bandcamp Player */}
+                  {block.music.bandcampEmbed && (
+                    <div className="mb-6 w-full overflow-hidden">
+                      <div
+                        className="w-full"
+                        dangerouslySetInnerHTML={{
+                          __html: block.music.bandcampEmbed,
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  {/* Streaming Links */}
+                  <div className="flex flex-wrap gap-6 text-base">
+                    {block.music.bandcampLink && (
+                      <Link
+                        href={block.music.bandcampLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:bg-accent bg-background cursor-pointer border-2 border-white px-2 text-lg font-medium text-white transition-colors hover:text-white"
+                      >
+                        Bandcamp
+                      </Link>
+                    )}
+                    {block.music.appleMusicUrl && (
+                      <Link
+                        href={block.music.appleMusicUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:bg-accent bg-background cursor-pointer border-2 border-white px-2 text-lg font-medium text-white transition-colors hover:text-white"
+                      >
+                        Apple Music
+                      </Link>
+                    )}
+                    {block.music.spotifyUrl && (
+                      <Link
+                        href={block.music.spotifyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:bg-accent bg-background cursor-pointer border-2 border-white px-2 text-lg font-medium text-white transition-colors hover:text-white"
+                      >
+                        Spotify
+                      </Link>
+                    )}
                   </div>
-                )}
+                </div>
               </div>
 
-              {/* Right Column - Music Player & Info */}
-              <div className="flex flex-col justify-start space-y-6">
-                {/* Bandcamp Player */}
-                {block.music.bandcampEmbed && (
-                  <div className="w-full">
-                    <div
-                      className="w-full"
-                      dangerouslySetInnerHTML={{
-                        __html: block.music.bandcampEmbed,
-                      }}
-                    />
+              {/* Left Column - Album Art */}
+              <div className="flex justify-center lg:order-1 lg:flex-shrink-0">
+                {block.music.albumCover && block.music.albumCover.asset ? (
+                  <div className="group relative">
+                    {/* Main image container */}
+                    <div className="">
+                      <Image
+                        src={urlFor(block.music.albumCover).url()}
+                        alt={block.music.albumName || "Album Cover"}
+                        className="h-64 w-auto object-cover transition-all duration-300 lg:h-[500px]"
+                        width={400}
+                        height={500}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex h-64 w-64 items-center justify-center border border-gray-300 bg-gray-100 shadow-lg lg:h-[500px] lg:w-[400px]">
+                    <span className="text-gray-500">Album Art</span>
                   </div>
                 )}
-
-                {/* Separator Line */}
-                <div className="border-t border-gray-600"></div>
-
-                {/* Streaming Links */}
-                <div className="flex flex-wrap justify-center gap-4 lg:justify-start">
-                  {block.music.bandcampLink && (
-                    <a
-                      href={block.music.bandcampLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-orange-400"
-                    >
-                      Bandcamp
-                    </a>
-                  )}
-                  {block.music.appleMusicUrl && (
-                    <a
-                      href={block.music.appleMusicUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-pink-400"
-                    >
-                      Apple Music
-                    </a>
-                  )}
-                  {block.music.spotifyUrl && (
-                    <a
-                      href={block.music.spotifyUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-lg font-semibold text-[#e0d6c3] underline transition-colors hover:text-green-400"
-                    >
-                      Spotify
-                    </a>
-                  )}
-                </div>
               </div>
             </div>
           </div>

--- a/src/sanity/queries.js
+++ b/src/sanity/queries.js
@@ -1,7 +1,22 @@
 import { groq } from "next-sanity";
 import { client } from "./lib/client";
 
-export const allMusicQuery = groq`*[_type == "music"]`;
+export const allMusicQuery = groq`
+  *[_type == "music"]{
+    _id,
+    albumCover{
+      asset->
+    },
+    albumName,
+    songs,
+    releaseDate,
+    artistName,
+    bandcampEmbed,
+    bandcampLink,
+    appleMusicUrl,
+    spotifyUrl
+  } | order(releaseDate desc)
+`;
 
 export const allCollaborationsQuery = groq`
   *[_type == "collaborations"]{
@@ -36,7 +51,24 @@ export const homePageQuery = groq`
       ...,
       image{
         asset->
-      }
+      },
+      ...select(_type == "reference" => {
+        ...,
+        "music": *[_id == ^._ref][0]{
+          _id,
+          albumCover{
+            asset->
+          },
+          albumName,
+          songs,
+          releaseDate,
+          artistName,
+          bandcampEmbed,
+          bandcampLink,
+          appleMusicUrl,
+          spotifyUrl
+        }
+      })
     }
   }
 `;
@@ -55,4 +87,8 @@ export async function getContactPage() {
 
 export async function getHomePage() {
   return await client.fetch(homePageQuery);
+}
+
+export async function getMusic() {
+  return await client.fetch(allMusicQuery);
 }

--- a/src/types/sanity.types.ts
+++ b/src/types/sanity.types.ts
@@ -50,11 +50,26 @@ export type Music = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  musicTitle?: string;
-  artistTitle?: string;
-  date?: string;
+  albumCover?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  albumName?: string;
+  songs?: Array<string>;
+  releaseDate?: string;
+  artistName?: string;
+  bandcampEmbed?: string;
   bandcampLink?: string;
-  description?: string;
+  appleMusicUrl?: string;
+  spotifyUrl?: string;
 };
 
 export type Collaborations = {


### PR DESCRIPTION
In this PR, we have added a new 'Music' type in the sanity studio. We therefore retrieve this type and display it as a reference type on the home page. Now, Isaac can create a new 'Music' object and then add it to the home page from the Page Builder.